### PR TITLE
Fix typo: issus -> issues

### DIFF
--- a/doc/known_issues.md
+++ b/doc/known_issues.md
@@ -1,5 +1,5 @@
 ---
-title: Known issus
+title: Known issues
 ---
 
 ## Targetd Plugin


### PR DESCRIPTION
Fixed a typo in the Knwon Issues page's title.
