### PR TITLE
Fix vimrc guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ autocmd Filetype markdown set tw=72
 " If in vim 7.3+, set color column at 72.
 if version >=703
     autocmd Filetype markdown set cc=72
-fi
+endif
 ```
 
 Please refer to [Github Help:Using Jekyll with Pages][2] for how


### PR DESCRIPTION
Conditions in vimrc are closed in `endif`, not with `fi`.

Signed-off-by: Allon Mureinik amureini@redhat.com
