### PR TITLE
install.md: Remove yum search

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -15,7 +15,6 @@ For RHEL/Centos 6 (in EPEL), RHEL/Centos 7 and Fedora you can install
 LSM via these commands:
 
 ```bash
-sudo yum search libstoragemgmt
 sudo yum install libstoragemgmt
 # Install plugins.
 sudo yum install libstoragemgmt-\*-plugin


### PR DESCRIPTION
`yum search` is useful when trying to locate specific packages, but
is not required for installing a package with a known name.

This patch removes this redundant step from the documentation.
Signed-off-by: Allon Mureinik amureini@redhat.com
